### PR TITLE
Cookie and CORS fix

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,5 @@ PORT=4000
 ENVIRONMENT=development
 DSN="mongodb://db:27017"
 JWT_TOKEN_SECRET=wonderfulsecretphrase
+CORS_ALLOWED_ORIGINS=http://* https://*
+COOKIE_NAME=uwu-blog-cookie

--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ A basic API for a blog page.
 
 All variables in the `.env` file are optional.
 
-| variable         | description                                                       | default                     | default-.env            |
-| ---------------- | ----------------------------------------------------------------- | --------------------------- | ----------------------- |
-| PORT             | the port number this server will listen on                        | `4000`                      | `4000`                  |
-| ENVIRONMENT      | has no impact whatsoever yet but can be seen in the server status | `development`               | `development`           |
-| DSN              | mongodb connection string                                         | `mongodb://localhost:27017` | `mongodb://db:27017`    |
-| JWT_TOKEN_SECRET | secret phrase for encrypting the passwords                        | `wonderfulsecretphrase`     | `wonderfulsecretphrase` |
+| variable             | description                                                       | default                     | default-.env            |
+| -------------------- | ----------------------------------------------------------------- | --------------------------- | ----------------------- |
+| PORT                 | the port number this server will listen on                        | `4000`                      | `4000`                  |
+| ENVIRONMENT          | has no impact whatsoever yet but can be seen in the server status | `development`               | `development`           |
+| DSN                  | mongodb connection string                                         | `mongodb://localhost:27017` | `mongodb://db:27017`    |
+| JWT_SECRET           | secret phrase for encrypting the passwords                        | `wonderfulsecretphrase`     | `wonderfulsecretphrase` |
+| CORS_ALLOWED_ORIGINS | allowed domains for CORS requests separated by spaces             | `http://* https://*`        | `http://* https://*`    |
+| COOKIE_NAME          | cookie name which gets set in the browser                         | `uwu-blog-cookie`           | `uwu-blog-cookie`       |
 
 ### docker-compose
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	serve := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),
-		Handler:      routes.Routes(),
+		Handler:      routes.Routes(app.Config.Cors),
 		IdleTimeout:  time.Minute,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 30 * time.Second,

--- a/config/config.go
+++ b/config/config.go
@@ -9,9 +9,11 @@ import (
 
 // Config represents the app's base configuration.
 type Config struct {
-	Port int
-	Env  string
-	DB   struct {
+	Port       int
+	Env        string
+	Cors       []string
+	CookieName string
+	DB         struct {
 		DSN string
 	}
 	JWT []byte

--- a/config/loadConfig.go
+++ b/config/loadConfig.go
@@ -3,6 +3,7 @@ package config
 import (
 	"log"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -30,8 +31,8 @@ func LoadConfig(cfg *Config) {
 
 	env, ok := viper.Get("ENVIRONMENT").(string)
 	if !ok {
-		env = "development"
-		log.Println("could not find environment. Defaulting to 'development'")
+		env = "dev"
+		log.Println("could not find environment. Defaulting to 'dev'")
 	}
 	cfg.Env = env
 
@@ -49,4 +50,18 @@ func LoadConfig(cfg *Config) {
 			"Defaulting to 'wonderfulsecretphrase'")
 	}
 	cfg.JWT = []byte(jwt)
+
+	corsString, ok := viper.Get("CORS_ALLOWED_ORIGINS").(string)
+	if !ok {
+		corsString = "http://* https://*"
+		log.Println("could not find cors allowed origin.", "Defaulting to 'http://*' and 'https://*'")
+	}
+	cfg.Cors = strings.Split(corsString, " ")
+
+	cookieName, ok := viper.Get("COOKIE_NAME").(string)
+	if !ok {
+		cookieName = "uwu-blog-cookie"
+		log.Println("could not find cookie name.", "Defaulting to 'uwu-blog-cookie'")
+	}
+	cfg.CookieName = cookieName
 }

--- a/config/loadConfig.go
+++ b/config/loadConfig.go
@@ -43,10 +43,10 @@ func LoadConfig(cfg *Config) {
 	}
 	cfg.DB.DSN = dsn
 
-	jwt, ok := viper.Get("JWT_TOKEN_SECRET").(string)
+	jwt, ok := viper.Get("JWT_SECRET").(string)
 	if !ok {
 		jwt = "wonderfulsecretphrase"
-		log.Println("could not find jwt token secret.",
+		log.Println("could not find jwt secret.",
 			"Defaulting to 'wonderfulsecretphrase'")
 	}
 	cfg.JWT = []byte(jwt)

--- a/controllers/authHandlers.go
+++ b/controllers/authHandlers.go
@@ -62,11 +62,13 @@ func (m *Repository) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cookie := &http.Cookie{
-		Name:     "jwt",
+		Name:     m.App.Config.CookieName,
 		Path:     "/",
 		Value:    tokenString,
 		Expires:  currTime.Add(time.Hour * 24),
 		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		// Secure:   true,
 	}
 
 	http.SetCookie(w, cookie)
@@ -83,7 +85,7 @@ func (m *Repository) Login(w http.ResponseWriter, r *http.Request) {
 // Logout logs the user out
 func (m *Repository) Logout(w http.ResponseWriter, r *http.Request) {
 	cookie := &http.Cookie{
-		Name:     "jwt",
+		Name:     m.App.Config.CookieName,
 		Path:     "/",
 		Value:    "",
 		Expires:  time.Now().Add(-time.Hour),

--- a/controllers/postHandlers.go
+++ b/controllers/postHandlers.go
@@ -38,7 +38,7 @@ func (m *Repository) InsertPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID, err := utils.GetIssuerFromCookie(r, m.App.Config.JWT)
+	userID, err := utils.GetIssuerFromCookie(r, m.App.Config.CookieName, m.App.Config.JWT)
 	if err != nil {
 		errorJSON(w, err)
 		return

--- a/middlewares/middleware.go
+++ b/middlewares/middleware.go
@@ -10,7 +10,7 @@ import (
 // Auth checks if the requests is authorized to access the endpoint.
 func (m *Repository) Auth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		issuer, err := utils.GetIssuerFromCookie(r, m.App.Config.JWT)
+		issuer, err := utils.GetIssuerFromCookie(r, m.App.Config.CookieName, m.App.Config.JWT)
 		if err != nil {
 			notAuthenticated(w, err)
 			return
@@ -37,7 +37,7 @@ func notAuthenticated(w http.ResponseWriter, err error) {
 // to modify or delete the target post.
 func (m *Repository) IsPostCreatorOrAdmin(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		issuer, err := utils.GetIssuerFromCookie(r, m.App.Config.JWT)
+		issuer, err := utils.GetIssuerFromCookie(r, m.App.Config.CookieName, m.App.Config.JWT)
 		if err != nil {
 			setStatusForbidden(w)
 			return
@@ -72,7 +72,7 @@ func (m *Repository) IsPostCreatorOrAdmin(next http.Handler) http.Handler {
 // change or delete the target user.
 func (m *Repository) IsUserOrAdmin(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		issuer, err := utils.GetIssuerFromCookie(r, m.App.Config.JWT)
+		issuer, err := utils.GetIssuerFromCookie(r, m.App.Config.CookieName, m.App.Config.JWT)
 		if err != nil {
 			setStatusForbidden(w)
 			return

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -8,10 +8,11 @@ import (
 )
 
 // Routes returns a fully configured Mux of the chi-router.
-func Routes() *chi.Mux {
+func Routes(corsAllowedOrigins []string) *chi.Mux {
 	r := chi.NewRouter()
 
 	r.Use(cors.Handler(cors.Options{
+		AllowedOrigins:   corsAllowedOrigins,
 		AllowedMethods:   []string{"GET", "POST", "PATCH", "DELETE"},
 		AllowCredentials: true,
 		MaxAge:           300,

--- a/utils/getCookieIssuer.go
+++ b/utils/getCookieIssuer.go
@@ -8,8 +8,8 @@ import (
 
 // GetIssuerFromCookie is a helper function that takes a request and tht
 // JWT_SECRET_TOKEN to retrieve the issuer and an error if any occured.
-func GetIssuerFromCookie(r *http.Request, jwtSecret []byte) (string, error) {
-	cookie, err := r.Cookie("jwt")
+func GetIssuerFromCookie(r *http.Request, cookieName string, jwtSecret []byte) (string, error) {
+	cookie, err := r.Cookie(cookieName)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Added SameSite=lax to cookies.
Cookie name now configurable in .env.

JWT_TOKEN_SECRET renamed to JWT_SECRET for better usability.

CORS default changed to "http://* https://*".
Added CORS_ALLOWED_ORIGINS for configuring allowed origins in the .env.

Adjusted README.md accordingly.